### PR TITLE
Update gk_music_free/admin/elements/update.php

### DIFF
--- a/gk_music_free/admin/elements/update.php
+++ b/gk_music_free/admin/elements/update.php
@@ -9,7 +9,10 @@ class JFormFieldUpdate extends JFormField {
 
 	protected function getInput() {
 	
+		if (DIRECTORY_SEPARATOR=='/')
 		$base_path = str_replace('admin/elements', '', dirname(__FILE__)).'templateDetails.xml';
+		else
+		$base_path = str_replace('admin/elements', '', str_replace('\\', '/', dirname(__FILE__))).'/templateDetails.xml';
 		$file_handle = fopen($base_path, "r");
 		$data = fread($file_handle, 2048);
 		preg_match('/<version>.*<\/version>/i', $data, $version);


### PR DESCRIPTION
Problem with the update element on Windows server due to slashes

This may not be the solution but it tested okay on Windows and Nix for me.

Original Windows error on clicking update tab as follows:-

Warning: fopen(Z:\Web\wamp\www\dev\cleantest\templates\gk_music_free\admin\elementstemplateDetails.xml) [function.fopen]: failed to open stream: No such file or directory in Z:\Web\wamp\www\dev\cleantest\templates\gk_music_free\admin\elements\update.php on line 13

Warning: fread() expects parameter 1 to be resource, boolean given in Z:\Web\wamp\www\dev\cleantest\templates\gk_music_free\admin\elements\update.php on line 14

Notice: Undefined offset: 0 in Z:\Web\wamp\www\dev\cleantest\templates\gk_music_free\admin\elements\update.php on line 16

Your template is up to date
